### PR TITLE
Add authentication and role-based access for staff actions

### DIFF
--- a/src/app.py
+++ b/src/app.py
@@ -5,14 +5,38 @@ A super simple FastAPI application that allows students to view and sign up
 for extracurricular activities at Mergington High School.
 """
 
-from fastapi import FastAPI, HTTPException
+from fastapi import FastAPI, HTTPException, Depends, Request, status
+from fastapi.security import HTTPBasic, HTTPBasicCredentials
+from fastapi.responses import JSONResponse
+import secrets
 from fastapi.staticfiles import StaticFiles
 from fastapi.responses import RedirectResponse
 import os
 from pathlib import Path
 
+
 app = FastAPI(title="Mergington High School API",
-              description="API for viewing and signing up for extracurricular activities")
+              description="API for viewing and signing up for extracurricular activities with authentication and role-based access")
+
+# Simple staff credentials (username: staff, password: merging123)
+STAFF_USERS = {
+    "staff@mergington.edu": {
+        "password": "merging123",
+        "role": "staff"
+    }
+}
+
+security = HTTPBasic()
+
+def get_current_staff(credentials: HTTPBasicCredentials = Depends(security)):
+    user = STAFF_USERS.get(credentials.username)
+    if not user or not secrets.compare_digest(credentials.password, user["password"]):
+        raise HTTPException(
+            status_code=status.HTTP_401_UNAUTHORIZED,
+            detail="Invalid credentials",
+            headers={"WWW-Authenticate": "Basic"},
+        )
+    return {"username": credentials.username, "role": user["role"]}
 
 # Mount the static files directory
 current_dir = Path(__file__).parent
@@ -88,45 +112,29 @@ def get_activities():
     return activities
 
 
+
+# Only staff can register students
 @app.post("/activities/{activity_name}/signup")
-def signup_for_activity(activity_name: str, email: str):
-    """Sign up a student for an activity"""
-    # Validate activity exists
+def signup_for_activity(activity_name: str, email: str, staff: dict = Depends(get_current_staff)):
+    """Sign up a student for an activity (staff only)"""
     if activity_name not in activities:
         raise HTTPException(status_code=404, detail="Activity not found")
-
-    # Get the specific activity
     activity = activities[activity_name]
-
-    # Validate student is not already signed up
     if email in activity["participants"]:
-        raise HTTPException(
-            status_code=400,
-            detail="Student is already signed up"
-        )
-
-    # Add student
+        raise HTTPException(status_code=400, detail="Student is already signed up")
     activity["participants"].append(email)
     return {"message": f"Signed up {email} for {activity_name}"}
 
 
+
+# Only staff can unregister students
 @app.delete("/activities/{activity_name}/unregister")
-def unregister_from_activity(activity_name: str, email: str):
-    """Unregister a student from an activity"""
-    # Validate activity exists
+def unregister_from_activity(activity_name: str, email: str, staff: dict = Depends(get_current_staff)):
+    """Unregister a student from an activity (staff only)"""
     if activity_name not in activities:
         raise HTTPException(status_code=404, detail="Activity not found")
-
-    # Get the specific activity
     activity = activities[activity_name]
-
-    # Validate student is signed up
     if email not in activity["participants"]:
-        raise HTTPException(
-            status_code=400,
-            detail="Student is not signed up for this activity"
-        )
-
-    # Remove student
+        raise HTTPException(status_code=400, detail="Student is not signed up for this activity")
     activity["participants"].remove(email)
     return {"message": f"Unregistered {email} from {activity_name}"}


### PR DESCRIPTION
This PR implements basic authentication and role-based access control:
- Only staff (username: staff@mergington.edu, password: merging123) can register or unregister students for activities.
- Students and others can still view activities, but cannot modify participation.

Implements the top-priority issue for security and user management.